### PR TITLE
rankings: make sorting stable

### DIFF
--- a/rankings/filter.go
+++ b/rankings/filter.go
@@ -31,7 +31,12 @@ func filterRankings(spRankings, mpRankings, overallRankings *[]*Player, players 
 
 	log.Println("sorting the ranks")
 	sort.Slice(*spRankings, func(i, j int) bool {
-		return (*spRankings)[i].SpScoreCount < (*spRankings)[j].SpScoreCount
+		a := (*spRankings)[i]
+		b := (*spRankings)[j]
+		if a.SpScoreCount == b.SpScoreCount {
+			return a.SteamID < b.SteamID
+		}
+		return a.SpScoreCount < b.SpScoreCount
 	})
 
 	rank := 1
@@ -52,7 +57,12 @@ func filterRankings(spRankings, mpRankings, overallRankings *[]*Player, players 
 	}
 
 	sort.Slice(*mpRankings, func(i, j int) bool {
-		return (*mpRankings)[i].MpScoreCount < (*mpRankings)[j].MpScoreCount
+		a := (*mpRankings)[i]
+		b := (*mpRankings)[j]
+		if a.MpScoreCount == b.MpScoreCount {
+			return a.SteamID < b.SteamID
+		}
+		return a.MpScoreCount < b.MpScoreCount
 	})
 
 	rank = 1
@@ -73,7 +83,12 @@ func filterRankings(spRankings, mpRankings, overallRankings *[]*Player, players 
 	}
 
 	sort.Slice(*overallRankings, func(i, j int) bool {
-		return (*overallRankings)[i].OverallScoreCount < (*overallRankings)[j].OverallScoreCount
+		a := (*overallRankings)[i]
+		b := (*overallRankings)[j]
+		if a.OverallScoreCount == b.OverallScoreCount {
+			return a.SteamID < b.SteamID
+		}
+		return a.OverallScoreCount < b.OverallScoreCount
 	})
 
 	rank = 1


### PR DESCRIPTION
Tried to optimize a few things but then noticed that the sorting is unstable which makes it hard to detect if the result is the same as before. Sorting by Steam ID on equal scores should make it stable since that field is always unique.

Example diff for sp.json where `sp_score` score is the same but higher Steam ID gets sorted to the back:

```diff
-  {
-    "user_name": "MrCatMcFly",
-    "avatar_link": "https://avatars.steamstatic.com/6f89591012f8f0f34cef1ecdb1c10793b0ea4bd1_full.jpg",
-    "steam_id": "76561198168920589",
-    "sp_score": 87,
-    "mp_score": 66,
-    "overall_score": 153,
-    "sp_rank": 15,
-    "mp_rank": 109,
-    "overall_rank": 28
-  },
   {
     "user_name": "BiSaXa",
     "avatar_link": "https://avatars.steamstatic.com/90864fe6d618dfeb65e0a336ae20dd949e916242_full.jpg",
@@ -175,6 +164,17 @@
     "mp_rank": 6,
     "overall_rank": 8
   },
+  {
+    "user_name": "MrCatMcFly",
+    "avatar_link": "https://avatars.steamstatic.com/6f89591012f8f0f34cef1ecdb1c10793b0ea4bd1_full.jpg",
+    "steam_id": "76561198168920589",
+    "sp_score": 87,
+    "mp_score": 66,
+    "overall_score": 153,
+    "sp_rank": 15,
+    "mp_rank": 109,
+    "overall_rank": 28
+  },
```