### PR TITLE
feat/rankings: optimize Steam ID comparison

### DIFF
--- a/rankings/fetch.go
+++ b/rankings/fetch.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 )
 
-func fetchLeaderboard(records []Record, overrides map[string]map[string]int, useCache bool) map[string]*Player {
+func fetchLeaderboard(records []Record, overrides map[SteamID]map[string]int, useCache bool) map[SteamID]*Player {
 	log.Println("fetching leaderboard")
-	players := map[string]*Player{}
+	players := map[SteamID]*Player{}
 	// first init players map with records from portal gun and doors
 	fetchAnotherPage := true
 	start := 0
@@ -187,7 +187,7 @@ func fetchPlayerInfo(players []*Player) {
 
 	ids := make([]string, len(players))
 	for _, player := range players {
-		ids = append(ids, player.SteamID)
+		ids = append(ids, strconv.FormatInt(int64(player.SteamID), 10))
 	}
 
 	url := fmt.Sprintf("http://api.steampowered.com/ISteamUser/GetPlayerSummaries/v2/?key=%s&steamids=%s", os.Getenv("API_KEY"), strings.Join(ids, ","))
@@ -200,9 +200,9 @@ func fetchPlayerInfo(players []*Player) {
 		log.Fatalln(err.Error())
 	}
 	type PlayerSummary struct {
-		SteamID     string `json:"steamid"`
-		PersonaName string `json:"personaname"`
-		AvatarFull  string `json:"avatarfull"`
+		SteamID     SteamID `json:"steamid"`
+		PersonaName string  `json:"personaname"`
+		AvatarFull  string  `json:"avatarfull"`
 	}
 
 	type Result struct {

--- a/rankings/filter.go
+++ b/rankings/filter.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 )
 
-func filterRankings(spRankings, mpRankings, overallRankings *[]*Player, players map[string]*Player) {
+func filterRankings(spRankings, mpRankings, overallRankings *[]*Player, players map[SteamID]*Player) {
 	for k, p := range players {
 		if p.SpIterations == 51 {
 			*spRankings = append(*spRankings, p)
@@ -109,7 +109,7 @@ func filterRankings(spRankings, mpRankings, overallRankings *[]*Player, players 
 	}
 }
 
-func chunkMap[T any](m map[string]*T, chunkSize int) [][]*T {
+func chunkMap[T any, K comparable](m map[K]*T, chunkSize int) [][]*T {
 	chunks := make([][]*T, 0, int(math.Ceil(float64(len(m))/float64(chunkSize))))
 	chunk := make([]*T, 0, chunkSize)
 

--- a/rankings/models.go
+++ b/rankings/models.go
@@ -1,5 +1,11 @@
 package main
 
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
 type Record struct {
 	MapID    int    `json:"id"`
 	MapName  string `json:"name"`
@@ -25,15 +31,34 @@ type LeaderboardEntries struct {
 	Entry []LeaderboardEntry `xml:"entry"`
 }
 
+type SteamID int64
+
+func (m SteamID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(strconv.FormatInt(int64(m), 10))
+}
+
+func (id *SteamID) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		n, err := strconv.ParseInt(s, 10, 64)
+		if err != nil {
+			return err
+		}
+		*id = SteamID(n)
+		return nil
+	}
+	return fmt.Errorf("invalid type for SteamID: %s", data)
+}
+
 type LeaderboardEntry struct {
-	SteamID string `xml:"steamid"`
-	Score   int    `xml:"score"`
+	SteamID SteamID `xml:"steamid"`
+	Score   int     `xml:"score"`
 }
 
 type Player struct {
 	Username          string        `json:"user_name"`
 	AvatarLink        string        `json:"avatar_link"`
-	SteamID           string        `json:"steam_id"`
+	SteamID           SteamID       `json:"steam_id"`
 	Entries           []PlayerEntry `json:"-"`
 	SpScoreCount      int           `json:"sp_score"`
 	MpScoreCount      int           `json:"mp_score"`

--- a/rankings/prefetch.go
+++ b/rankings/prefetch.go
@@ -25,7 +25,7 @@ func readRecords() []Record {
 	return records
 }
 
-func readOverrides() map[string]map[string]int {
+func readOverrides() map[SteamID]map[string]int {
 	overridesFile, err := os.Open("./input/overrides.json")
 	if err != nil {
 		log.Fatalln(err.Error())
@@ -35,7 +35,7 @@ func readOverrides() map[string]map[string]int {
 	if err != nil {
 		log.Fatalln(err.Error())
 	}
-	overrides := map[string]map[string]int{}
+	overrides := map[SteamID]map[string]int{}
 	err = json.Unmarshal(overridesFileBytes, &overrides)
 	if err != nil {
 		log.Fatalln(err.Error())


### PR DESCRIPTION
Since the Steam ID is a 64bit integer we should compare it in registers directly instead of comparing a string byte by byte. The string representation is only needed when constructing the URL to call the profile API and when exporting the data.

It's a µ-optimization so this does not speed up the program too much since the biggest slowdown will always be network requests.

Profiled this small code section:
```go
start := time.Now()

for _, profile := range data.Response.Players {
	for _, player := range players {
		if player.SteamID == profile.SteamID {
			player.AvatarLink = profile.AvatarFull
			player.Username = profile.PersonaName
		}
	}
}

duration := time.Since(start)
fmt.Printf("took: %v\n", duration)
```

```bash
# main
2024/11/16 22:01:23 fetching info for 100 players
took: 262.425µs
2024/11/16 22:01:24 fetching info for 100 players
took: 246.73µs
2024/11/16 22:01:25 fetching info for 92 players
took: 209.21µs

# this pr ~8x faster
2024/11/16 22:05:00 fetching info for 100 players
took: 31.959µs
2024/11/16 22:05:00 fetching info for 100 players
took: 31.688µs
2024/11/16 22:05:01 fetching info for 92 players
took: 26.985µs
```